### PR TITLE
Add synthetic text-to-video example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,31 @@
+# AI Video Generator (Synthetic Characters)
+
+This project demonstrates how to create short videos from text prompts using a diffusion-based text-to-video model. The goal is to generate synthetic characters or scenes only. Do not use this code to impersonate real people or to generate videos of real individuals.
+
+## Setup
+
+1. Install the required Python packages (Python 3.8+ recommended):
+   ```bash
+   pip install torch torchvision --extra-index-url https://download.pytorch.org/whl/cu118
+   pip install diffusers[torch] transformers
+   pip install opencv-python moviepy
+   ```
+   Adjust the CUDA version in the PyTorch URL based on your GPU.
+
+2. Ensure you have a machine with a GPU for efficient generation. Using CPU will be very slow.
+
+## Usage
+
+Run the script with a text prompt that describes the desired scene. Prompts should only reference fictional or synthetic characters.
+
+```bash
+python text_to_video_synthetic.py "a 3d animated person dancing in a futuristic city" --num_frames 16 --out_path dancing.mp4
+```
+
+This will generate about 16 frames from the prompt and compile them into `dancing.mp4`.
+
+## Notes
+
+- The script uses the `damo-vilab/text-to-video-ms-1.7b` model from the `diffusers` library.
+- Generation speed and quality depend on your hardware.
+- Avoid uploading or referencing real people's images or likenesses. This code is intended only for synthetic characters.

--- a/text_to_video_synthetic.py
+++ b/text_to_video_synthetic.py
@@ -1,0 +1,43 @@
+import argparse
+import torch
+import numpy as np
+from diffusers import DiffusionPipeline
+from moviepy.editor import ImageSequenceClip
+
+
+def main(prompt: str, num_frames: int = 16, out_path: str = "output.mp4", fps: int = 8) -> None:
+    """Generate a short video from a text prompt using a diffusion model.
+
+    Parameters
+    ----------
+    prompt : str
+        Text describing the desired scene with fictional or synthetic characters.
+    num_frames : int, optional
+        Number of frames to generate. Default is 16.
+    out_path : str, optional
+        Output video file path. Default is "output.mp4".
+    fps : int, optional
+        Frames per second for the output video. Default is 8.
+    """
+    model_id = "damo-vilab/text-to-video-ms-1.7b"
+    pipe = DiffusionPipeline.from_pretrained(model_id, torch_dtype=torch.float16)
+    pipe = pipe.to("cuda" if torch.cuda.is_available() else "cpu")
+
+    result = pipe(prompt, num_frames=num_frames)
+    frames = result.frames
+
+    frame_arrays = [np.array(frame) for frame in frames]
+    clip = ImageSequenceClip(frame_arrays, fps=fps)
+    clip.write_videofile(out_path, codec="libx264")
+    print(f"Video saved to {out_path}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Generate a video of synthetic characters from text.")
+    parser.add_argument("prompt", help="Text describing the scene (fictional characters only)")
+    parser.add_argument("--num_frames", type=int, default=16, help="Number of frames to generate")
+    parser.add_argument("--out_path", default="output.mp4", help="Output video file path")
+    parser.add_argument("--fps", type=int, default=8, help="Frames per second for the output video")
+    args = parser.parse_args()
+
+    main(args.prompt, args.num_frames, args.out_path, args.fps)


### PR DESCRIPTION
## Summary
- create a Python script `text_to_video_synthetic.py` with a small pipeline for generating short videos of synthetic characters from text prompts
- add `README.md` explaining setup and usage for producing fictional videos

## Testing
- `python -m py_compile text_to_video_synthetic.py`


------
https://chatgpt.com/codex/tasks/task_e_683f8b2f8ddc8329927d24601335ec71